### PR TITLE
feat: get all portfolios by user id

### DIFF
--- a/.docker/postgres/init.sql
+++ b/.docker/postgres/init.sql
@@ -35,8 +35,7 @@ CREATE TABLE prod.portfolio (
     pid BIGINT DEFAULT nextval('portfolio_id_seq') PRIMARY KEY,
     user_id BIGINT REFERENCES prod.user(id),
     portfolio_name VARCHAR(255),
-    description TEXT,
-    creation_date DATE
+    description TEXT
 );
 
 CREATE TYPE asset_types AS ENUM ('Stock', 'ETF');
@@ -74,9 +73,9 @@ INSERT INTO prod.user (email, username) VALUES ('user2@example.com', 'user2');
 INSERT INTO prod.user (email, username) VALUES ('user3@example.com', 'user3');
 
 
-INSERT INTO prod.portfolio (user_id, portfolio_name, description, creation_date) VALUES (1, 'Flagship Portfolio', 'My companys flagship portfolio.', '2023-10-09');
-INSERT INTO prod.portfolio (user_id, portfolio_name, description, creation_date) VALUES (2, 'ESG Portfolio', 'This is my ESG portfolio entry.', '2023-10-09');
-INSERT INTO prod.portfolio (user_id, portfolio_name, description, creation_date) VALUES (2, 'SGX Portfolio', 'This is a special portfolio entry in Singapore!', '2023-10-09');
+INSERT INTO prod.portfolio (user_id, portfolio_name, description) VALUES (1, 'Flagship Portfolio', 'My companys flagship portfolio.');
+INSERT INTO prod.portfolio (user_id, portfolio_name, description) VALUES (2, 'ESG Portfolio', 'This is my ESG portfolio entry.');
+INSERT INTO prod.portfolio (user_id, portfolio_name, description) VALUES (2, 'SGX Portfolio', 'This is a special portfolio entry in Singapore!');
 
 
 INSERT INTO prod.asset (asset_ticker, asset_name, asset_description, asset_industry, asset_type) VALUES ('TSLA', 'Tesla Inc', 'Tesla, Inc. is an American electric vehicle and clean energy company based in Palo Alto, California. Teslas current products include electric cars, battery energy storage from home to grid-scale, solar panels and solar roof tiles, as well as other related products and services. In 2020, Tesla had the highest sales in the plug-in and battery electric passenger car segments, capturing 16% of the plug-in market (which includes plug-in hybrids) and 23% of the battery-electric (purely electric) market. Through its subsidiary Tesla Energy, the company develops and is a major installer of solar photovoltaic energy generation systems in the United States. Tesla Energy is also one of the largest global suppliers of battery energy storage systems, with 3 GWh of battery storage supplied in 2020.', 'Technology', 'Stock');

--- a/src/main/java/com/backend/controller/PortfolioController.java
+++ b/src/main/java/com/backend/controller/PortfolioController.java
@@ -65,6 +65,7 @@ public class PortfolioController {
 		);
 		System.out.println(portfolio.getPid());
 
+
 		CreatePortfolioResponse response = new CreatePortfolioResponse();
 		response.setPid(portfolio.getPid());
 		response.setUserId(portfolio.getUserId());

--- a/src/main/java/com/backend/controller/PortfolioController.java
+++ b/src/main/java/com/backend/controller/PortfolioController.java
@@ -59,8 +59,7 @@ public class PortfolioController {
 			new Portfolio(
 				request.getUserId(),
 				request.getPortfolioName(),
-				request.getDescription(),
-				request.getCreationDate()
+				request.getDescription()
 			)
 		);
 		System.out.println(portfolio.getPid());
@@ -71,7 +70,6 @@ public class PortfolioController {
 		response.setUserId(portfolio.getUserId());
 		response.setPortfolioName(portfolio.getPortfolioName());
 		response.setDescription(portfolio.getDescription());
-		response.setCreationDate(portfolio.getCreationDate());
 
 		return response;
 	}
@@ -85,7 +83,6 @@ public class PortfolioController {
 		response.setUserId(portfolio.getUserId());
 		response.setPortfolioName(portfolio.getPortfolioName());
 		response.setDescription(portfolio.getDescription());
-		response.setCreationDate(portfolio.getCreationDate());
 
 		return response;
 	}

--- a/src/main/java/com/backend/controller/UserController.java
+++ b/src/main/java/com/backend/controller/UserController.java
@@ -57,7 +57,7 @@ public class UserController {
         response.setId(user.getId());
         response.setEmail(user.getEmail());
         response.setUsername(user.getUsername());
-        response.setPortfolios(user.getPortfolios());
+        response.setPortfolioList(user.getPortfolios());
         
         return response;
     }

--- a/src/main/java/com/backend/controller/UserController.java
+++ b/src/main/java/com/backend/controller/UserController.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,7 +21,9 @@ import com.backend.model.User;
 import com.backend.request.CreateUserRequest;
 import com.backend.response.CreateUserResponse;
 import com.backend.response.FindAllUsersResponse;
+import com.backend.response.FindUserResponse;
 import com.backend.service.abstractions.IUserService;
+import com.backend.service.concretions.UserService;
 
 @RestController
 @RequestMapping(produces = { MediaType.APPLICATION_JSON_VALUE })
@@ -42,6 +45,18 @@ public class UserController {
 
         FindAllUsersResponse response = new FindAllUsersResponse();
         response.setUserList(userList);
+        return response;
+    }
+
+    @GetMapping("/users/{id}")
+    public FindUserResponse findById(@PathVariable long id) {
+        User user = userService.findById(id);
+        
+        FindUserResponse response = new FindUserResponse();
+        response.setId(user.getId());
+        response.setEmail(user.getEmail());
+        response.setUsername(user.getUsername());
+
         return response;
     }
 

--- a/src/main/java/com/backend/controller/UserController.java
+++ b/src/main/java/com/backend/controller/UserController.java
@@ -14,13 +14,16 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.service.annotation.GetExchange;
 
 import com.backend.configuration.Constants;
 import com.backend.exception.BadRequestException;
+import com.backend.model.Portfolio;
 import com.backend.model.User;
 import com.backend.request.CreateUserRequest;
 import com.backend.response.CreateUserResponse;
 import com.backend.response.FindAllUsersResponse;
+import com.backend.response.FindUserPortfolios;
 import com.backend.response.FindUserResponse;
 import com.backend.service.abstractions.IUserService;
 import com.backend.service.concretions.UserService;
@@ -89,6 +92,18 @@ public class UserController {
         response.setUsername(user.getUsername());
         response.setEmail(user.getEmail());
         return response;
+    }
+
+    @GetMapping("/users/{id}/portfolios")
+    public FindUserPortfolios findUserPortolios(@PathVariable long id) {
+        List<Portfolio> portfolios = userService.findUserPortfolios(id);
+        FindUserPortfolios response = new FindUserPortfolios();
+
+        response.setPortfolioList(portfolios);
+
+        return response;
+    
+
     }
 
 }

--- a/src/main/java/com/backend/controller/UserController.java
+++ b/src/main/java/com/backend/controller/UserController.java
@@ -96,6 +96,7 @@ public class UserController {
 
     @GetMapping("/users/{id}/portfolios")
     public FindUserPortfolios findUserPortolios(@PathVariable long id) {
+        logger.info("Finding user " + id + " portfolio");
         List<Portfolio> portfolios = userService.findUserPortfolios(id);
         FindUserPortfolios response = new FindUserPortfolios();
 

--- a/src/main/java/com/backend/controller/UserController.java
+++ b/src/main/java/com/backend/controller/UserController.java
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.service.annotation.GetExchange;
 
 import com.backend.configuration.Constants;
 import com.backend.exception.BadRequestException;
@@ -26,7 +25,6 @@ import com.backend.response.FindAllUsersResponse;
 import com.backend.response.FindUserPortfolios;
 import com.backend.response.FindUserResponse;
 import com.backend.service.abstractions.IUserService;
-import com.backend.service.concretions.UserService;
 
 @RestController
 @RequestMapping(produces = { MediaType.APPLICATION_JSON_VALUE })
@@ -59,7 +57,8 @@ public class UserController {
         response.setId(user.getId());
         response.setEmail(user.getEmail());
         response.setUsername(user.getUsername());
-
+        response.setPortfolios(user.getPortfolios());
+        
         return response;
     }
 

--- a/src/main/java/com/backend/exception/UserNotFoundException.java
+++ b/src/main/java/com/backend/exception/UserNotFoundException.java
@@ -7,4 +7,8 @@ public class UserNotFoundException extends RuntimeException {
     public UserNotFoundException(String email) {
         super("Could not find user " + email);
     }
+
+    public UserNotFoundException(long id) {
+        super("User not found");
+    }
 }

--- a/src/main/java/com/backend/model/Portfolio.java
+++ b/src/main/java/com/backend/model/Portfolio.java
@@ -3,9 +3,14 @@ package com.backend.model;
 import lombok.Data;
 import java.time.LocalDate;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
+
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.Column;
 import jakarta.persistence.SequenceGenerator;
@@ -20,9 +25,16 @@ public class Portfolio {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "portfolio-sequence-gen")
     private long pid;
-    
-    @Column(name = "user_id")
+
+    @JsonBackReference
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="user_id", nullable = false)
+    // private long userId;
+    private User user;
+
+    @Column(name = "user_id", insertable=false, updatable=false)
     private long userId;
+
 
     @Column(name = "portfolio_name")
     private String portfolioName;
@@ -40,4 +52,9 @@ public class Portfolio {
         this.description = description;
         this.creationDate = creationDate;
     }
+
+    // public long getUserId() {
+    //     return this.user.getId();
+    // }
+
 }

--- a/src/main/java/com/backend/model/Portfolio.java
+++ b/src/main/java/com/backend/model/Portfolio.java
@@ -28,11 +28,11 @@ public class Portfolio {
 
     @JsonBackReference
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="user_id", nullable = false)
+    @JoinColumn(name="user_id", nullable = false, insertable=false, updatable=false)
     // private long userId;
     private User user;
 
-    @Column(name = "user_id", insertable=false, updatable=false)
+    @Column(name = "user_id")
     private long userId;
 
 

--- a/src/main/java/com/backend/model/Portfolio.java
+++ b/src/main/java/com/backend/model/Portfolio.java
@@ -1,7 +1,6 @@
 package com.backend.model;
 
 import lombok.Data;
-import java.time.LocalDate;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 
@@ -40,17 +39,14 @@ public class Portfolio {
     private String portfolioName;
     private String description;
 
-    @Column(name = "creation_date")
-    private LocalDate creationDate;
 
     protected Portfolio(){
     }
 
-    public Portfolio(long userId, String portfolioName, String description, LocalDate creationDate) {
+    public Portfolio(long userId, String portfolioName, String description) {
         this.userId = userId;
         this.portfolioName = portfolioName;
         this.description = description;
-        this.creationDate = creationDate;
     }
 
     // public long getUserId() {

--- a/src/main/java/com/backend/model/User.java
+++ b/src/main/java/com/backend/model/User.java
@@ -2,6 +2,8 @@ package com.backend.model;
 
 import java.util.List;
 
+import javax.sound.sampled.Port;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -23,6 +25,9 @@ public class User {
     private Long id;
     private String email;
     private String username;
+
+    @OneToMany(mappedBy = "user")
+    private List<Portfolio> portfolios;
 
     protected User() {
     }

--- a/src/main/java/com/backend/repository/PortfolioRepository.java
+++ b/src/main/java/com/backend/repository/PortfolioRepository.java
@@ -8,5 +8,5 @@ import com.backend.model.Portfolio;
 @RepositoryRestResource(exported = false)
 public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
     Portfolio findByPid(int pid);
-    Portfolio findAllByUserId(int userId);
+    // Portfolio findAllByUserId(long userId);
 }

--- a/src/main/java/com/backend/repository/PortfolioRepository.java
+++ b/src/main/java/com/backend/repository/PortfolioRepository.java
@@ -8,5 +8,4 @@ import com.backend.model.Portfolio;
 @RepositoryRestResource(exported = false)
 public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
     Portfolio findByPid(int pid);
-    // Portfolio findAllByUserId(long userId);
 }

--- a/src/main/java/com/backend/repository/UserRepository.java
+++ b/src/main/java/com/backend/repository/UserRepository.java
@@ -9,4 +9,5 @@ import com.backend.model.User;
 public interface UserRepository extends JpaRepository<User, Long> {
     User findByUsername(String username);
     User findByEmail(String email);
+    User findById(long id);
 }

--- a/src/main/java/com/backend/request/CreatePortfolioRequest.java
+++ b/src/main/java/com/backend/request/CreatePortfolioRequest.java
@@ -3,13 +3,10 @@ package com.backend.request;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-import java.time.LocalDate;
-
 @Data
 @EqualsAndHashCode(callSuper = false)
 public class CreatePortfolioRequest extends BaseRequest {
     private long userId;
     private String portfolioName;
     private String description;
-    private LocalDate creationDate;
 }

--- a/src/main/java/com/backend/response/CreatePortfolioResponse.java
+++ b/src/main/java/com/backend/response/CreatePortfolioResponse.java
@@ -2,13 +2,10 @@ package com.backend.response;
 
 import lombok.Data;
 
-import java.time.LocalDate;
-
 @Data
 public class CreatePortfolioResponse {
     private long pid;
     private long userId;
     private String portfolioName;
     private String description;
-    private LocalDate creationDate;
 }

--- a/src/main/java/com/backend/response/FindUserPortfolios.java
+++ b/src/main/java/com/backend/response/FindUserPortfolios.java
@@ -1,0 +1,13 @@
+package com.backend.response;
+
+import java.util.List;
+
+import com.backend.model.Portfolio;
+
+import lombok.Data;
+
+@Data
+public class FindUserPortfolios {
+    List<Portfolio> portfolioList;
+
+}

--- a/src/main/java/com/backend/response/FindUserResponse.java
+++ b/src/main/java/com/backend/response/FindUserResponse.java
@@ -11,5 +11,5 @@ public class FindUserResponse {
     private long id;
     private String username;
     private String email;
-    List<Portfolio> portfolios;
+    List<Portfolio> portfolioList;
 }

--- a/src/main/java/com/backend/response/FindUserResponse.java
+++ b/src/main/java/com/backend/response/FindUserResponse.java
@@ -1,5 +1,9 @@
 package com.backend.response;
 
+import java.util.List;
+
+import com.backend.model.Portfolio;
+
 import lombok.Data;
 @Data
 
@@ -7,4 +11,5 @@ public class FindUserResponse {
     private long id;
     private String username;
     private String email;
+    List<Portfolio> portfolios;
 }

--- a/src/main/java/com/backend/response/FindUserResponse.java
+++ b/src/main/java/com/backend/response/FindUserResponse.java
@@ -1,0 +1,10 @@
+package com.backend.response;
+
+import lombok.Data;
+@Data
+
+public class FindUserResponse {
+    private long id;
+    private String username;
+    private String email;
+}

--- a/src/main/java/com/backend/response/GetPortfolioByIdResponse.java
+++ b/src/main/java/com/backend/response/GetPortfolioByIdResponse.java
@@ -1,6 +1,5 @@
 package com.backend.response;
 
-import java.time.LocalDate;
 import lombok.Data;
 
 @Data
@@ -9,5 +8,4 @@ public class GetPortfolioByIdResponse {
     private long userId;
     private String portfolioName;
     private String description;
-    private LocalDate creationDate;
 }

--- a/src/main/java/com/backend/service/abstractions/IUserService.java
+++ b/src/main/java/com/backend/service/abstractions/IUserService.java
@@ -11,4 +11,5 @@ public interface IUserService {
     User findByEmail(String email);
     boolean isUsernameExist(String username);
     boolean isEmailExist(String email);
+    User findById(long id);
 }

--- a/src/main/java/com/backend/service/abstractions/IUserService.java
+++ b/src/main/java/com/backend/service/abstractions/IUserService.java
@@ -2,6 +2,7 @@ package com.backend.service.abstractions;
 
 import java.util.List;
 
+import com.backend.model.Portfolio;
 import com.backend.model.User;
 
 public interface IUserService {
@@ -12,4 +13,5 @@ public interface IUserService {
     boolean isUsernameExist(String username);
     boolean isEmailExist(String email);
     User findById(long id);
+    List<Portfolio> findUserPortfolios(long id);
 }

--- a/src/main/java/com/backend/service/concretions/UserService.java
+++ b/src/main/java/com/backend/service/concretions/UserService.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.backend.exception.UserNotFoundException;
+import com.backend.model.Portfolio;
 import com.backend.model.User;
 import com.backend.repository.UserRepository;
 
@@ -67,6 +68,16 @@ public class UserService implements com.backend.service.abstractions.IUserServic
             throw new UserNotFoundException(id);
         } else {
             return user;
+        }
+    }
+
+    @Override
+    public List<Portfolio> findUserPortfolios(long id) {
+        User user = repository.findById(id);
+        if (user == null) {
+            throw new UserNotFoundException(id);
+        } else {
+            return user.getPortfolios();
         }
     }
 }

--- a/src/main/java/com/backend/service/concretions/UserService.java
+++ b/src/main/java/com/backend/service/concretions/UserService.java
@@ -59,4 +59,14 @@ public class UserService implements com.backend.service.abstractions.IUserServic
         User user = repository.findByEmail(email);
         return user != null;
     }
+
+    @Override 
+    public User findById(long id) {
+        User user = repository.findById(id);
+        if (user == null) {
+            throw new UserNotFoundException(id);
+        } else {
+            return user;
+        }
+    }
 }


### PR DESCRIPTION
closes #5 

## Context

This PR addresses the following: 
1. get user by Id 
2. get all portfolios by user id

## Set up
---
Set up local env,  run ```make dev``` if on Mac OR ```.make.bat dev``` if on Windows


## Get User By Id
---
1. Make a ```GET``` request to ```http:localhost:8080/api/users/{id}``` where id is the id of the user you are searching for
2. For example, if id is 1, you should see: 

```json
{
    "id": 1,
    "username": "user1",
    "email": "user1@example.com",
    "portfolioList": [
        {
            "pid": 1,
            "userId": 1,
            "portfolioName": "Flagship Portfolio",
            "description": "My companys flagship portfolio."
        }
    ]
}
```

## Get all portfolios by user id
1. Make a ```GET``` request to ```http:localhost:8080/api/users/{id}/portfolios``` where id is the id of the user and you should see: 
```json
{
  "portfolioList": [
        {
            "pid": 1,
            "userId": 1,
            "portfolioName": "Flagship Portfolio",
            "description": "My companys flagship portfolio."
        }
    ]
}
```





