### PR TITLE
feat: update portfolio metadata

### DIFF
--- a/src/main/java/com/backend/configuration/Constants.java
+++ b/src/main/java/com/backend/configuration/Constants.java
@@ -2,7 +2,8 @@ package com.backend.configuration;
 
 public final class Constants {
 
-    private Constants() {}
+    private Constants() {
+    }
 
     public static final String MAIN_CURRENCY = "SGD";
 
@@ -15,4 +16,5 @@ public final class Constants {
     public static final String MESSAGE_INVALIDHISTORICALCALL = "Incorrect request. Appropriate query parameters are 1week, 1month, 6month, 1year, 5year and all";
     public static final String MESSAGE_INVALIDPORTFOLIOID = "Portfolio id is missing";
     public static final String MESSAGE_INVALIDASSETID = "Asset id is missing";
+    public static final String MESSAGE_MISSINGPORTFOLIOMETADATA = "Either portfolion name or description is required to update portfolio metadata";
 }

--- a/src/main/java/com/backend/configuration/Constants.java
+++ b/src/main/java/com/backend/configuration/Constants.java
@@ -16,5 +16,5 @@ public final class Constants {
     public static final String MESSAGE_INVALIDHISTORICALCALL = "Incorrect request. Appropriate query parameters are 1week, 1month, 6month, 1year, 5year and all";
     public static final String MESSAGE_INVALIDPORTFOLIOID = "Portfolio id is missing";
     public static final String MESSAGE_INVALIDASSETID = "Asset id is missing";
-    public static final String MESSAGE_MISSINGPORTFOLIOMETADATA = "Either portfolion name or description is required to update portfolio metadata";
+    public static final String MESSAGE_MISSINGPORTFOLIOMETADATA = "Either portfolio name or description is required to update portfolio metadata";
 }

--- a/src/main/java/com/backend/controller/PortfolioController.java
+++ b/src/main/java/com/backend/controller/PortfolioController.java
@@ -5,14 +5,12 @@ import java.util.Map;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,7 +18,6 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 import com.backend.model.Asset;
 import com.backend.configuration.Constants;
 import com.backend.exception.BadRequestException;
@@ -29,14 +26,13 @@ import com.backend.model.Portfolio;
 import com.backend.model.PortfolioAsset;
 import com.backend.request.CreatePortfolioAssetRequest;
 import com.backend.request.CreatePortfolioRequest;
+import com.backend.request.UpdatePortfolioMetaDataRquest;
 import com.backend.response.CreatePortfolioAssetResponse;
 import com.backend.response.CreatePortfolioResponse;
 import com.backend.response.FindAllPortfoliosResponse;
 import com.backend.response.GetAllAssetsByPortfolioIdResponse;
 import com.backend.response.GetPortfolioByIdResponse;
-import com.backend.response.UpdatePortfolioMetadata;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
+import com.backend.response.UpdatePortfolioMetadataResponse;
 import com.backend.service.abstractions.IAssetService;
 import com.backend.service.abstractions.IPortfolioAssetService;
 import com.backend.service.abstractions.IPortfolioService;
@@ -108,17 +104,21 @@ public class PortfolioController {
 	}
 
 	@PutMapping(path = "/portfolio/{pid}")
-	public UpdatePortfolioMetadata updatePortfolio(@PathVariable long pid, @RequestBody Map<String, String> body) {
+	public UpdatePortfolioMetadataResponse updatePortfolio(@PathVariable long pid,
+			@RequestBody UpdatePortfolioMetaDataRquest body) {
 		Portfolio portfolio = portfolioService.findByPid(pid);
+
 		if (portfolio == null) {
 			throw new PortfolioAssetNotFoundException(pid);
 		}
+
 		logger.info("Beginning update of portfolio with the following details");
 		logger.info("Portfolio ID: " + pid);
-		logger.info("New Portfolio Name: " + body.get("portfolioName"));
-		logger.info("New Portfolio Description: " + body.get("description"));
-		String portfolioName = body.get("portfolioName");
-		String description = body.get("description");
+		logger.info("New Portfolio Name: " + body.getPortfolioName());
+		logger.info("New Portfolio Description: " + body.getDescription());
+
+		String portfolioName = body.getPortfolioName();
+		String description = body.getDescription();
 
 		if (portfolioName == null && description == null) {
 			throw new BadRequestException(Constants.MESSAGE_MISSINGPORTFOLIOMETADATA);
@@ -131,8 +131,10 @@ public class PortfolioController {
 		}
 
 		portfolioService.updatePortfolio(portfolio);
+
 		logger.info("Portfolio updated successfully");
-		UpdatePortfolioMetadata response = new UpdatePortfolioMetadata();
+
+		UpdatePortfolioMetadataResponse response = new UpdatePortfolioMetadataResponse();
 		response.setPortfolioName(portfolio.getPortfolioName());
 		response.setDescription(portfolio.getDescription());
 

--- a/src/main/java/com/backend/controller/PortfolioController.java
+++ b/src/main/java/com/backend/controller/PortfolioController.java
@@ -116,6 +116,7 @@ public class PortfolioController {
 		logger.info("Beginning update of portfolio with the following details");
 		logger.info("Portfolio ID: " + pid);
 		logger.info("New Portfolio Name: " + body.get("portfolioName"));
+		logger.info("New Portfolio Description: " + body.get("description"));
 		String portfolioName = body.get("portfolioName");
 		String description = body.get("description");
 

--- a/src/main/java/com/backend/request/UpdatePortfolioMetaDataRquest.java
+++ b/src/main/java/com/backend/request/UpdatePortfolioMetaDataRquest.java
@@ -1,0 +1,11 @@
+package com.backend.request;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class UpdatePortfolioMetaDataRquest extends BaseRequest {
+    String portfolioName;
+    String description;
+}

--- a/src/main/java/com/backend/response/UpdatePortfolioMetadata.java
+++ b/src/main/java/com/backend/response/UpdatePortfolioMetadata.java
@@ -1,0 +1,9 @@
+package com.backend.response;
+
+import lombok.Data;
+
+@Data
+public class UpdatePortfolioMetadata {
+    private String portfolioName;
+    private String description;
+}

--- a/src/main/java/com/backend/response/UpdatePortfolioMetadataResponse.java
+++ b/src/main/java/com/backend/response/UpdatePortfolioMetadataResponse.java
@@ -3,7 +3,7 @@ package com.backend.response;
 import lombok.Data;
 
 @Data
-public class UpdatePortfolioMetadata {
+public class UpdatePortfolioMetadataResponse {
     private String portfolioName;
     private String description;
 }

--- a/src/main/java/com/backend/service/abstractions/IPortfolioService.java
+++ b/src/main/java/com/backend/service/abstractions/IPortfolioService.java
@@ -6,6 +6,10 @@ import com.backend.model.Portfolio;
 
 public interface IPortfolioService {
     List<Portfolio> findAll();
+
     Portfolio createNewPortfolio(Portfolio portfolio);
+
     Portfolio findByPid(long pid);
+
+    Portfolio updatePortfolio(Portfolio portfolio);
 }

--- a/src/main/java/com/backend/service/concretions/PortfolioService.java
+++ b/src/main/java/com/backend/service/concretions/PortfolioService.java
@@ -9,7 +9,6 @@ import com.backend.model.Portfolio;
 import com.backend.repository.PortfolioRepository;
 import com.backend.exception.PortfolioNotFoundException;
 
-
 @Service
 public class PortfolioService implements com.backend.service.abstractions.IPortfolioService {
     private final PortfolioRepository repository;
@@ -25,18 +24,23 @@ public class PortfolioService implements com.backend.service.abstractions.IPortf
     }
 
     @Override
-    public Portfolio createNewPortfolio(Portfolio portfolio){
+    public Portfolio createNewPortfolio(Portfolio portfolio) {
         return repository.save(portfolio);
     }
 
     @Override
-    public Portfolio findByPid(long pid){
+    public Portfolio findByPid(long pid) {
         Portfolio portfolio = repository.findByPid(pid);
 
-        if (portfolio == null){
+        if (portfolio == null) {
             throw new PortfolioNotFoundException(pid);
-        }
-        else
+        } else
             return portfolio;
     }
+
+    @Override
+    public Portfolio updatePortfolio(Portfolio updatedPortfolio) {
+        return repository.save(updatedPortfolio);
+    }
+
 }


### PR DESCRIPTION
Closes #28 

## Features
- error handling for `pid` not found
- error handling for if both `portfolioName` and `description` not in request body
- logging

## Route
PUT: `/portfolio/<pid>`

## Demo
![CleanShot 2023-11-05 at 00 25 28](https://github.com/is442oop/portfolio-analyzer-backend/assets/68373112/2bc6d137-5125-4f29-997c-119230cb7bf6)
