### PR TITLE
formatting asset ticker response for transaction modal

### DIFF
--- a/src/main/java/com/backend/controller/AssetController.java
+++ b/src/main/java/com/backend/controller/AssetController.java
@@ -64,9 +64,9 @@ public class AssetController {
         
         for(Asset asset : assetList) {
             AssetFormatResponse response = new AssetFormatResponse();
-            response.setAssetValue(asset.getAssetName().toLowerCase());
-            response.setAssetName(asset.getAssetName());
-            response.setAssetTicker(asset.getAssetTicker().trim());
+            response.setValue(asset.getAssetName().toLowerCase());
+            response.setLabel(asset.getAssetName());
+            response.setTicker(asset.getAssetTicker().trim());
             responseList.add(response);
         }
         return responseList;

--- a/src/main/java/com/backend/controller/AssetController.java
+++ b/src/main/java/com/backend/controller/AssetController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import com.backend.model.Asset;
 import com.backend.response.GetAssetByTickerResponse;
 import com.backend.response.AssetResponse;
+import com.backend.response.AssetFormatResponse;
 import com.backend.service.abstractions.IAssetService;
 
 @RestController
@@ -54,6 +55,20 @@ public class AssetController {
             responseList.add(response);
         }
         return responseList;
+    }
 
+    @GetMapping(path = "/asset/format")
+    public List<AssetFormatResponse> getAssetsByIndustry() {
+        List<Asset> assetList = assetService.findAll();
+        List<AssetFormatResponse> responseList = new ArrayList<>();
+        
+        for(Asset asset : assetList) {
+            AssetFormatResponse response = new AssetFormatResponse();
+            response.setAssetValue(asset.getAssetName().toLowerCase());
+            response.setAssetName(asset.getAssetName());
+            response.setAssetTicker(asset.getAssetTicker().trim());
+            responseList.add(response);
+        }
+        return responseList;
     }
 }

--- a/src/main/java/com/backend/controller/AssetController.java
+++ b/src/main/java/com/backend/controller/AssetController.java
@@ -57,7 +57,7 @@ public class AssetController {
         return responseList;
     }
 
-    @GetMapping(path = "/asset/format")
+    @GetMapping(path = "/assets/format")
     public List<AssetFormatResponse> getAssetsByIndustry() {
         List<Asset> assetList = assetService.findAll();
         List<AssetFormatResponse> responseList = new ArrayList<>();

--- a/src/main/java/com/backend/response/AssetFormatResponse.java
+++ b/src/main/java/com/backend/response/AssetFormatResponse.java
@@ -3,9 +3,9 @@ package com.backend.response;
 import lombok.Data;
 @Data
 public class AssetFormatResponse {
-    private String assetValue;
-    private String assetName;
-    private String assetTicker;
+    private String value;
+    private String label;
+    private String ticker;
 }
 
 

--- a/src/main/java/com/backend/response/AssetFormatResponse.java
+++ b/src/main/java/com/backend/response/AssetFormatResponse.java
@@ -1,0 +1,14 @@
+package com.backend.response;
+
+import lombok.Data;
+@Data
+public class AssetFormatResponse {
+    private String assetValue;
+    private String assetName;
+    private String assetTicker;
+}
+
+
+// value: "apple",
+// label: "Apple",
+// ticker: "AAPL",


### PR DESCRIPTION
### Changes

Added an extra API endpoint just to format the tickers for transaction modal.

### Expected Output

Currently, the frontend is using hardcoded data that is formatted like this:

`[{
        value: "alphabet inc.",
        label: "Alphabet Inc.",
        ticker: "GOOGL",
    },
    {
        value: "amazon",
        label: "Amazon",
        ticker: "AMZN",
    }]
`

### Demo


https://github.com/is442oop/portfolio-analyzer-backend/assets/77909441/4b63efe8-f19a-4143-b3d6-ed6ce3ba1318
