### PR TITLE
feat: delete portfolio with cascade (delete portfolioAsset)

### DIFF
--- a/.docker/postgres/init.sql
+++ b/.docker/postgres/init.sql
@@ -49,7 +49,7 @@ CREATE TABLE prod.asset (
 --- Create the 'portfolio_asset' table under the 'prod' schema with the portfolio_asset_id_seq as the default value for the pid column
 CREATE TABLE prod.portfolio_asset (
     portfolio_asset_id BIGINT DEFAULT nextval('portfolio_asset_id_seq') PRIMARY KEY,
-    portfolio_id BIGINT NOT NULL REFERENCES prod.portfolio(pid),
+    portfolio_id BIGINT NOT NULL REFERENCES prod.portfolio(pid) ON DELETE CASCADE,
     -- asset_id BIGINT NOT NULL  REFERENCES prod.asset(asset_id),
     asset_ticker VARCHAR(15) NOT NULL REFERENCES prod.asset(asset_ticker),
     price DECIMAL NOT NULL,

--- a/src/main/java/com/backend/controller/PortfolioController.java
+++ b/src/main/java/com/backend/controller/PortfolioController.java
@@ -31,11 +31,14 @@ import com.backend.request.CreatePortfolioRequest;
 import com.backend.request.UpdatePortfolioMetaDataRquest;
 import com.backend.response.CreatePortfolioAssetResponse;
 import com.backend.response.CreatePortfolioResponse;
+import com.backend.response.DeletePortfolioResponse;
 import com.backend.response.FindAllPortfoliosResponse;
 import com.backend.response.GetAllAssetsByPortfolioIdResponse;
 import com.backend.response.GetAllPortfolioAssetsByUserResponse;
+import com.backend.response.GetPortfolioAssetResponse;
 import com.backend.response.GetPortfolioByIdResponse;
 import com.backend.response.UpdatePortfolioMetadataResponse;
+import com.backend.service.abstractions.IAssetService;
 import com.backend.service.abstractions.IPortfolioAssetService;
 import com.backend.service.abstractions.IPortfolioService;
 import com.backend.service.abstractions.IUserService;
@@ -370,5 +373,32 @@ public class PortfolioController {
         response.setPortfolioAssetList(output);
         return response;
     }
+
+	@DeleteMapping(path = "/portfolios/{pid}")
+		public DeletePortfolioResponse deletePortfolio(@PathVariable long pid){
+			// check if pid is valid
+			Portfolio portfolio = portfolioService.findByPid(pid);
+			if (portfolio == null) {
+				throw new PortfolioNotFoundException(pid);
+			}
+			portfolioService.deletePortfolio(pid);
+			DeletePortfolioResponse response = new DeletePortfolioResponse();
+			response.setMessage("Portfolio with pid=" + pid + " deleted successfully");
+
+			return response;
+	}
+
+	// get portfolioAsset by portfolioAssetId
+	@GetMapping(path = "/portfolio/asset/{portfolioAssetId}")
+	public GetPortfolioAssetResponse getPortfolioAssetByPortfolioAssetId(@PathVariable long portfolioAssetId) {
+		PortfolioAsset portfolioAsset = portfolioAssetService.findByPortfolioAssetId(portfolioAssetId);
+		if (portfolioAsset == null) {
+			throw new PortfolioAssetNotFoundException(portfolioAssetId);
+		}
+		GetPortfolioAssetResponse response = new GetPortfolioAssetResponse();
+		response.setPortfolioAsset(portfolioAsset);
+
+		return response;
+	}
 
 }

--- a/src/main/java/com/backend/controller/PortfolioController.java
+++ b/src/main/java/com/backend/controller/PortfolioController.java
@@ -388,8 +388,7 @@ public class PortfolioController {
 			return response;
 	}
 
-	// get portfolioAsset by portfolioAssetId
-	@GetMapping(path = "/portfolio/asset/{portfolioAssetId}")
+	@GetMapping(path = "/portfolios/assets/{portfolioAssetId}")
 	public GetPortfolioAssetResponse getPortfolioAssetByPortfolioAssetId(@PathVariable long portfolioAssetId) {
 		PortfolioAsset portfolioAsset = portfolioAssetService.findByPortfolioAssetId(portfolioAssetId);
 		if (portfolioAsset == null) {

--- a/src/main/java/com/backend/model/PortfolioAsset.java
+++ b/src/main/java/com/backend/model/PortfolioAsset.java
@@ -7,6 +7,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
 
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
 import com.fasterxml.jackson.annotation.JsonBackReference;
 
 import jakarta.persistence.Entity;
@@ -35,6 +38,7 @@ public class PortfolioAsset {
     @JsonBackReference
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "portfolio_id", nullable = false, insertable = false, updatable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Portfolio portfolio;
 
     @Column(name = "portfolio_id")

--- a/src/main/java/com/backend/response/DeletePortfolioResponse.java
+++ b/src/main/java/com/backend/response/DeletePortfolioResponse.java
@@ -1,0 +1,8 @@
+package com.backend.response;
+
+import lombok.Data;
+
+@Data
+public class DeletePortfolioResponse {
+    private String message;
+}

--- a/src/main/java/com/backend/response/GetPortfolioAssetResponse.java
+++ b/src/main/java/com/backend/response/GetPortfolioAssetResponse.java
@@ -1,0 +1,11 @@
+package com.backend.response;
+
+import com.backend.model.PortfolioAsset;
+
+import lombok.Data;
+
+@Data
+public class GetPortfolioAssetResponse {
+    private PortfolioAsset portfolioAsset;
+}
+

--- a/src/main/java/com/backend/service/abstractions/IPortfolioService.java
+++ b/src/main/java/com/backend/service/abstractions/IPortfolioService.java
@@ -12,4 +12,6 @@ public interface IPortfolioService {
     Portfolio findByPid(long pid);
 
     Portfolio updatePortfolio(Portfolio portfolio);
+
+    void deletePortfolio(long pid);
 }

--- a/src/main/java/com/backend/service/concretions/PortfolioService.java
+++ b/src/main/java/com/backend/service/concretions/PortfolioService.java
@@ -43,4 +43,9 @@ public class PortfolioService implements com.backend.service.abstractions.IPortf
         return repository.save(updatedPortfolio);
     }
 
+    @Override
+    public void deletePortfolio(long pid) {
+        repository.deleteById(pid);
+    }
+
 }


### PR DESCRIPTION
## Pre-req
Portfolio with pid=1 exists with the following portfolioAssets as shown
![image](https://github.com/is442oop/portfolio-analyzer-backend/assets/101630007/ade80212-2b58-4793-85d2-987bf78ea873)

## Steps
Send DELETE request to http://127.0.0.1:8080/api/portfolios/1

## Output
Returns a JSON

```json
{
    "message": "Portfolio with pid=1 deleted successfully"
}
```

## Validation
Sending a GET req to search for portfolioAssets in Portfolio with pid=1 returns an error

![image](https://github.com/is442oop/portfolio-analyzer-backend/assets/101630007/1a2eb029-1962-427c-8c57-1db46f845241)

Searching for portfolioAsset with portfolioAssetId=8
![image](https://github.com/is442oop/portfolio-analyzer-backend/assets/101630007/9098eb49-5f96-421b-b65c-6657fe2cc29a)

